### PR TITLE
Table/View example for device inventory

### DIFF
--- a/pyez/TableView/README
+++ b/pyez/TableView/README
@@ -1,0 +1,1 @@
+This script will collect juniper device chassis inventory like PEM, RE, FPC, MIC, PIC and PORT

--- a/pyez/TableView/get_inventory.py
+++ b/pyez/TableView/get_inventory.py
@@ -1,0 +1,29 @@
+from jnpr.junos import Device
+from jnpr.junos.factory.factory_loader import FactoryLoader
+import yaml,sys
+router_name = "xxx"
+
+with open("table_views.yml", 'r') as tvs:
+    globals().update(FactoryLoader().load(yaml.load(tvs)))
+with Device(host=router_name, user='xxxxx', password='xxxx', gather_facts=False) as dev:
+    inv = ChassisInventoryTable(dev)
+    inv.get()
+    print "Collecting hardware inventory from router and update into file inventory.csv"
+    f = open("inventory.csv", 'w')
+    sys.stdout = f
+    for item in inv:
+        print "Router Name",",","Item Name",",","Description",",","Serial Number",",","Part Number",",","Version",",","Model Number"
+        print router_name,",",item.name,",",item.desc,",",item.sn
+    
+        for i in [item.FPM, item.FDM, item.PEM, item.RE]:
+            for j in i:
+                print router_name,",",j.name,",",j.desc,",",j.sn,",",j.pn,",",j.ver,",",j.model
+        for k in item.FPC:
+            print router_name,",",k.name,",",k.desc,",",k.sn,",",k.pn,",",k.ver,",",j.model
+            for l in k.MIC:
+                print router_name,",",l.name,",",l.desc,",",l.sn,",",l.pn,",",l.ver,",",j.model
+                for m in l.PIC:
+                    print router_name,",",m.name,",",m.desc,",",m.sn,",",m.pn
+                    for n in m.PORT:
+                        print router_name,",",n.name,",",n.desc,",",n.sn,",",n.pn,",",n.ver
+    f.close()

--- a/pyez/TableView/table_views.yml
+++ b/pyez/TableView/table_views.yml
@@ -1,0 +1,134 @@
+# -------------------------------------------------------------------
+# Table
+# -------------------------------------------------------------------
+# retrieve the chassis hardware (inventory) and extract the Chassis
+# items.
+# -------------------------------------------------------------------
+
+---
+ChassisInventoryTable:
+    rpc: get-chassis-inventory
+    item: .//name[starts-with(.,'Chassis')]/parent::*
+    view: _chassis_inventory_view
+
+# -------------------------------------------------------------------
+# View
+# -------------------------------------------------------------------
+# use the underscore (_) so this definition is not
+# imported into the glboal namespace. We want to extract various
+# bits of information from the Chassis items
+# -------------------------------------------------------------------
+
+_chassis_inventory_view:
+    fields:
+        name: name
+        desc: description
+        sn: serial-number
+        FPM: FpmHwTable
+        FDM: FpmHwTable
+        PEM: PemHwTable
+        RE: ReHwTable
+        FPC: FpcHwTable
+
+FpmHwTable:
+    item: .//name[starts-with(.,'FPM')]/parent::*
+    view: _fpm_hw_view
+_fpm_hw_view:
+    fields:
+        name: name
+        sn: serial-number
+        pn: part-number
+        ver: version
+        model: model-number
+        desc: description
+
+FdmHwTable:
+    item: .//name[starts-with(.,'FDM')]/parent::*
+    view: _fdm_hw_view
+_fdm_hw_view:
+    fields:
+        name: name
+        sn: serial-number
+        pn: part-number
+        ver: version
+        model: model-number
+        desc: description
+
+PemHwTable:
+    item: .//name[starts-with(.,'PEM')]/parent::*
+    view: _pem_hw_view
+
+PemHwTable:
+    item: .//name[starts-with(.,'PEM')]/parent::*
+    view: _pem_hw_view
+_pem_hw_view:
+    fields:
+        name: name
+        sn: serial-number
+        pn: part-number
+        ver: version
+        model: model-number
+        desc: description
+
+ReHwTable:
+    item: .//name[starts-with(.,'Routing Engine')]/parent::*
+    view: _re_hw_view
+_re_hw_view:
+    fields:
+        name: name
+        sn: serial-number
+        pn: part-number
+        ver: version
+        model: model-number
+        desc: description
+
+FpcHwTable:
+    item: .//name[starts-with(.,'FPC')]/parent::*
+    view: _fpc_hw_view
+
+_fpc_hw_view:
+    fields:
+        name: name
+        sn: serial-number
+        pn: part-number
+        ver: version
+        model: model-number
+        desc: description
+        MIC: MicHwTable
+        PIC: PicHwTable
+MicHwTable:
+    item: .//name[starts-with(.,'MIC')]/parent::*
+    view: _mic_hw_view
+_mic_hw_view:
+    fields:
+        name: name
+        sn: serial-number
+        pn: part-number
+        ver: version
+        model: model-number
+        desc: description
+        PIC: PicHwTable
+
+PicHwTable:
+    item: .//name[starts-with(.,'PIC')]/parent::*
+    view: _pic_hw_view
+_pic_hw_view:
+    fields:
+        name: name
+        sn: serial-number
+        pn: part-number
+        ver: version
+        desc: description
+        PORT: PortHwTable
+
+PortHwTable:
+    item: .//name[starts-with(.,'Xcvr')]/parent::*
+    view: _port_hw_view
+_port_hw_view:
+    fields:
+        name: name
+        sn: serial-number
+        pn: part-number
+        ver: version
+        desc: description
+        


### PR DESCRIPTION
PyEz Table and View feature get information from juniper router using xml rpcs and provides output in tabular format
Table and View feature can be used to get;

 -  Juniper device chassis inventory like PEM, RE, FPC, MIC, PIC and PORT
 - Protocol stats
 - Interface stats and lot many
